### PR TITLE
Turn off JSDoc example linting

### DIFF
--- a/javascript/jsdoc/index.js
+++ b/javascript/jsdoc/index.js
@@ -27,7 +27,6 @@ module.exports = [
     name: '@nextcapital/eslint-config/jsdoc - Enable plugin recommended rules as errors',
     ...pluginJSDoc.configs['flat/recommended-error']
   },
-  ...pluginJSDoc.configs.examples,
   ...nextcapitalJSDoc,
   {
     name: '@nextcapital/eslint-config/jsdoc - Disable require-jsdoc in test files',

--- a/javascript/jsdoc/rules.js
+++ b/javascript/jsdoc/rules.js
@@ -1,5 +1,7 @@
 module.exports = {
   rules: {
+    'jsdoc/check-examples': 'off',
+
     'jsdoc/informative-docs': 'warn',
 
     'jsdoc/no-bad-blocks': 'warn',

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcapital/eslint-config",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcapital/eslint-config",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/js": "^9.19.0",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcapital/eslint-config",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "ESLint config to enforce our styleguide",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
## Notes

<!--

🚨 THIS REPO IS PUBLIC! Be mindful of what you post here. 🚨

-->

## Version change

We use [Semantic Versioning 2.0](https://semver.org/)

- [ ] Major - Non-backwards compatible changes
- [ ] Minor - Backwards compatible changes
- [ ] Patch - Backwards-compatible bug fix
- [ ] None - Internal changes

## Procedural Steps

All commits have been signed-off for the Developer Certificate of Origin. See https://github.com/NextCapital/maybe/blob/main/CONTRIBUTING.md#dco-sign-off-methods

